### PR TITLE
Adds taggings support and some minor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Feedbin [![Build Status](https://travis-ci.org/ColbyAley/feedbin.png?branch=master)](https://travis-ci.org/ColbyAley/feedbin)
 ===
 
-A simple Ruby wrapper for v2 of the [Feedbin.me](http://feedbin.me) REST [API](https://github.com/feedbin/feedbin-api). Includes functionality for retrieving entries and subscribing to feeds.
+A simple Ruby wrapper for v2 of the [Feedbin.com](http://feedbin.com) REST [API](https://github.com/feedbin/feedbin-api). Includes functionality for retrieving entries and subscribing to feeds.
 
 This is an unoficial gem, and is not affiliated with Feedbin.
 

--- a/lib/feedbin.rb
+++ b/lib/feedbin.rb
@@ -12,44 +12,44 @@ class FeedbinAPI
   # Entries
 
   def entries(options = {})
-    HTTParty.get("https://api.feedbin.me/v2/entries.json", query: options, basic_auth: basic_auth)
+    HTTParty.get("https://api.feedbin.com/v2/entries.json", query: options, basic_auth: basic_auth)
   end
 
   def entries_for_feed(id)
-    HTTParty.get("https://api.feedbin.me/v2/feeds/#{id}/entries.json", basic_auth: basic_auth)
+    HTTParty.get("https://api.feedbin.com/v2/feeds/#{id}/entries.json", basic_auth: basic_auth)
   end
 
   def entry(id)
-    HTTParty.get("https://api.feedbin.me/v2/entries/#{id}.json", basic_auth: basic_auth)
+    HTTParty.get("https://api.feedbin.com/v2/entries/#{id}.json", basic_auth: basic_auth)
   end
 
   def unread_entries
-    HTTParty.get("https://api.feedbin.me/v2/unread_entries.json", basic_auth: basic_auth)
+    HTTParty.get("https://api.feedbin.com/v2/unread_entries.json", basic_auth: basic_auth)
   end
 
   def star(id)
-    HTTParty.post("https://api.feedbin.me/v2/starred_entries.json",
+    HTTParty.post("https://api.feedbin.com/v2/starred_entries.json",
       body: { 'starred_entries' => id }.to_json,
       headers: { 'Content-Type' => 'application/json' },
       basic_auth: basic_auth).code
   end
 
   def unstar(id)
-    HTTParty.post("https://api.feedbin.me/v2/starred_entries/delete.json",
+    HTTParty.post("https://api.feedbin.com/v2/starred_entries/delete.json",
       body: { 'starred_entries' => id }.to_json,
       headers: { 'Content-Type' => 'application/json' },
       basic_auth: basic_auth).code
   end
 
   def mark_as_read(id)
-    HTTParty.post("https://api.feedbin.me/v2/unread_entries/delete.json",
+    HTTParty.post("https://api.feedbin.com/v2/unread_entries/delete.json",
       body: { 'unread_entries' => id }.to_json,
       headers: { 'Content-Type' => 'application/json' },
       basic_auth: basic_auth).code
   end
 
   def mark_as_unread(id)
-    HTTParty.post("https://api.feedbin.me/v2/unread_entries.json",
+    HTTParty.post("https://api.feedbin.com/v2/unread_entries.json",
       body: { 'unread_entries' => id }.to_json,
       headers: { 'Content-Type' => 'application/json' },
       basic_auth: basic_auth).code
@@ -58,28 +58,28 @@ class FeedbinAPI
   # Feeds
 
   def feed(id)
-    HTTParty.get("https://api.feedbin.me/v2/feeds/#{id}.json", basic_auth: basic_auth)
+    HTTParty.get("https://api.feedbin.com/v2/feeds/#{id}.json", basic_auth: basic_auth)
   end
 
   # Subscriptions
 
   def subscribe(url)
-    HTTParty.post("https://api.feedbin.me/v2/subscriptions.json",
+    HTTParty.post("https://api.feedbin.com/v2/subscriptions.json",
       body: { 'feed_url' => url }.to_json,
       headers: { 'Content-Type' => 'application/json' },
       basic_auth: basic_auth).code
   end
 
   def unsubscribe(id)
-    HTTParty.delete("https://api.feedbin.me/v2/subscriptions/#{id}.json", basic_auth: basic_auth).code
+    HTTParty.delete("https://api.feedbin.com/v2/subscriptions/#{id}.json", basic_auth: basic_auth).code
   end
 
   def subscriptions(options = {})
     if options[:since]
-      resp = HTTParty.get("https://api.feedbin.me/v2/subscriptions.json", query: { since: options[:since] }, basic_auth: basic_auth)
+      resp = HTTParty.get("https://api.feedbin.com/v2/subscriptions.json", query: { since: options[:since] }, basic_auth: basic_auth)
       return resp == [] ? resp : 'There have been no subscriptions since this date.'.to_json unless resp.code != 200
     else
-      HTTParty.get("https://api.feedbin.me/v2/subscriptions.json", basic_auth: basic_auth)
+      HTTParty.get("https://api.feedbin.com/v2/subscriptions.json", basic_auth: basic_auth)
     end
   end
 

--- a/lib/feedbin.rb
+++ b/lib/feedbin.rb
@@ -15,8 +15,12 @@ class FeedbinAPI
     HTTParty.get("https://api.feedbin.com/v2/entries.json", query: options, basic_auth: basic_auth)
   end
 
-  def entries_for_feed(id)
-    HTTParty.get("https://api.feedbin.com/v2/feeds/#{id}/entries.json", basic_auth: basic_auth)
+  def entries_for_feed(id, options = {})
+    HTTParty.get(
+      "https://api.feedbin.com/v2/feeds/#{id}/entries.json",
+      query:options,
+      basic_auth: basic_auth
+    )
   end
 
   def entry(id)

--- a/lib/feedbin.rb
+++ b/lib/feedbin.rb
@@ -65,6 +65,16 @@ class FeedbinAPI
     HTTParty.get("https://api.feedbin.com/v2/feeds/#{id}.json", basic_auth: basic_auth)
   end
 
+  # Tags
+
+  def tag(id)
+    HTTParty.get("https://api.feedbin.com/v2/taggings/#{id}.json", basic_auth: basic_auth)
+  end
+
+  def tags
+    HTTParty.get('https://api.feedbin.com/v2/taggings.json', basic_auth: basic_auth)
+  end
+
   # Subscriptions
 
   def subscribe(url)

--- a/lib/feedbin.rb
+++ b/lib/feedbin.rb
@@ -67,11 +67,15 @@ class FeedbinAPI
 
   # Tags
 
-  def tag(id)
+  def tags
+    HTTParty.get("https://api.feedbin.com/v2/tags.json", basic_auth: basic_auth)
+  end
+
+  def tagging(id)
     HTTParty.get("https://api.feedbin.com/v2/taggings/#{id}.json", basic_auth: basic_auth)
   end
 
-  def tags
+  def taggings
     HTTParty.get('https://api.feedbin.com/v2/taggings.json', basic_auth: basic_auth)
   end
 

--- a/spec/feedbin_spec.rb
+++ b/spec/feedbin_spec.rb
@@ -8,13 +8,13 @@ describe FeedbinAPI do
 
   describe '#entries' do
   	it 'should get entries and return a 200' do
-      stub_request(:get, "https://api.feedbin.me/v2/entries.json?")
+      stub_request(:get, "https://api.feedbin.com/v2/entries.json?")
         .with(basic_auth: ['email', 'password']).to_return(status: 200)
       expect(@feedbin.entries.code).to eq(200)
   	end
 
     it 'should return a 200 when parameter is passed' do
-      stub_request(:get, "https://api.feedbin.me/v2/entries.json?read=false")
+      stub_request(:get, "https://api.feedbin.com/v2/entries.json?read=false")
         .with(basic_auth: ['email', 'password']).to_return(status: 200)
       expect(@feedbin.entries(read: false).code).to eq(200)
     end
@@ -22,7 +22,7 @@ describe FeedbinAPI do
 
   describe '#entries_for_feed' do
     it 'should get entries for a feed and return a 200' do
-      stub_request(:get, "https://api.feedbin.me/v2/feeds/42/entries.json")
+      stub_request(:get, "https://api.feedbin.com/v2/feeds/42/entries.json")
         .with(basic_auth: ['email', 'password']).to_return(status: 200)
       expect(@feedbin.entries_for_feed(42).code).to eq(200)
     end
@@ -30,7 +30,7 @@ describe FeedbinAPI do
 
   describe '#subscriptions' do
     it 'should get subscriptions and return a 200' do
-      stub_request(:get, "https://api.feedbin.me/v2/subscriptions.json")
+      stub_request(:get, "https://api.feedbin.com/v2/subscriptions.json")
         .with(basic_auth: ['email', 'password']).to_return(status: 200)
       expect(@feedbin.subscriptions.code).to eq(200)
     end
@@ -38,7 +38,7 @@ describe FeedbinAPI do
 
   describe '#unsubscribe' do
     it 'should unsubscribe and return a 204' do
-      stub_request(:delete, "https://api.feedbin.me/v2/subscriptions/260815.json")
+      stub_request(:delete, "https://api.feedbin.com/v2/subscriptions/260815.json")
         .with(basic_auth: ['email', 'password']).to_return(status: 204)
       expect(@feedbin.unsubscribe(260815)).to eq(204)
     end
@@ -46,7 +46,7 @@ describe FeedbinAPI do
 
   describe '#feed' do
     it 'should get feed and return a 200' do
-      stub_request(:get, "https://api.feedbin.me/v2/feeds/1.json")
+      stub_request(:get, "https://api.feedbin.com/v2/feeds/1.json")
         .with(basic_auth: ['email', 'password']).to_return(status: 200)
       expect(@feedbin.feed(1).code).to eq(200)
     end
@@ -54,13 +54,13 @@ describe FeedbinAPI do
 
   describe '#star' do
     it 'should star a post and return a 200' do
-      stub_request(:post, "https://api.feedbin.me/v2/starred_entries.json")
+      stub_request(:post, "https://api.feedbin.com/v2/starred_entries.json")
         .with(basic_auth: ['email', 'password']).to_return(status: 200)
       expect(@feedbin.star(33)).to eq(200)
     end
 
     it 'should star an array of posts and return a 200' do
-      stub_request(:post, "https://api.feedbin.me/v2/starred_entries.json")
+      stub_request(:post, "https://api.feedbin.com/v2/starred_entries.json")
         .with(basic_auth: ['email', 'password']).to_return(status: 200)
       expect(@feedbin.star([33,44,55,66,77])).to eq(200)
     end

--- a/spec/feedbin_spec.rb
+++ b/spec/feedbin_spec.rb
@@ -28,6 +28,22 @@ describe FeedbinAPI do
     end
   end
 
+  describe '#tag' do
+    it 'should get subscriptions and return a 200' do
+      stub_request(:get, "https://api.feedbin.com/v2/taggings/42.json")
+        .with(basic_auth: ['email', 'password']).to_return(status: 200)
+      expect(@feedbin.tag(42).code).to eq(200)
+    end
+  end
+
+  describe '#tags' do
+    it 'should get subscriptions and return a 200' do
+      stub_request(:get, "https://api.feedbin.com/v2/taggings.json")
+        .with(basic_auth: ['email', 'password']).to_return(status: 200)
+      expect(@feedbin.tags.code).to eq(200)
+    end
+  end
+
   describe '#subscriptions' do
     it 'should get subscriptions and return a 200' do
       stub_request(:get, "https://api.feedbin.com/v2/subscriptions.json")

--- a/spec/feedbin_spec.rb
+++ b/spec/feedbin_spec.rb
@@ -8,52 +8,60 @@ describe FeedbinAPI do
 
   describe '#entries' do
   	it 'should get entries and return a 200' do
-      stub_request(:get, "https://email:password@api.feedbin.me/v2/entries.json?").to_return(status: 200)
+      stub_request(:get, "https://api.feedbin.me/v2/entries.json?")
+        .with(basic_auth: ['email', 'password']).to_return(status: 200)
       expect(@feedbin.entries.code).to eq(200)
   	end
 
     it 'should return a 200 when parameter is passed' do
-      stub_request(:get, "https://email:password@api.feedbin.me/v2/entries.json?read=false").to_return(status: 200)
+      stub_request(:get, "https://api.feedbin.me/v2/entries.json?read=false")
+        .with(basic_auth: ['email', 'password']).to_return(status: 200)
       expect(@feedbin.entries(read: false).code).to eq(200)
     end
   end
 
   describe '#entries_for_feed' do
     it 'should get entries for a feed and return a 200' do
-      stub_request(:get, "https://email:password@api.feedbin.me/v2/feeds/42/entries.json").to_return(status: 200)
+      stub_request(:get, "https://api.feedbin.me/v2/feeds/42/entries.json")
+        .with(basic_auth: ['email', 'password']).to_return(status: 200)
       expect(@feedbin.entries_for_feed(42).code).to eq(200)
     end
   end
 
   describe '#subscriptions' do
     it 'should get subscriptions and return a 200' do
-      stub_request(:get, "https://email:password@api.feedbin.me/v2/subscriptions.json").to_return(status: 200)
+      stub_request(:get, "https://api.feedbin.me/v2/subscriptions.json")
+        .with(basic_auth: ['email', 'password']).to_return(status: 200)
       expect(@feedbin.subscriptions.code).to eq(200)
     end
   end
 
   describe '#unsubscribe' do
     it 'should unsubscribe and return a 204' do
-      stub_request(:delete, "https://email:password@api.feedbin.me/v2/subscriptions/260815.json").to_return(status: 204)
+      stub_request(:delete, "https://api.feedbin.me/v2/subscriptions/260815.json")
+        .with(basic_auth: ['email', 'password']).to_return(status: 204)
       expect(@feedbin.unsubscribe(260815)).to eq(204)
     end
   end
 
   describe '#feed' do
     it 'should get feed and return a 200' do
-      stub_request(:get, "https://email:password@api.feedbin.me/v2/feeds/1.json").to_return(status: 200)
+      stub_request(:get, "https://api.feedbin.me/v2/feeds/1.json")
+        .with(basic_auth: ['email', 'password']).to_return(status: 200)
       expect(@feedbin.feed(1).code).to eq(200)
     end
   end
 
   describe '#star' do
     it 'should star a post and return a 200' do
-      stub_request(:post, "https://email:password@api.feedbin.me/v2/starred_entries.json").to_return(status: 200)
+      stub_request(:post, "https://api.feedbin.me/v2/starred_entries.json")
+        .with(basic_auth: ['email', 'password']).to_return(status: 200)
       expect(@feedbin.star(33)).to eq(200)
     end
 
     it 'should star an array of posts and return a 200' do
-      stub_request(:post, "https://email:password@api.feedbin.me/v2/starred_entries.json").to_return(status: 200)
+      stub_request(:post, "https://api.feedbin.me/v2/starred_entries.json")
+        .with(basic_auth: ['email', 'password']).to_return(status: 200)
       expect(@feedbin.star([33,44,55,66,77])).to eq(200)
     end
   end

--- a/spec/feedbin_spec.rb
+++ b/spec/feedbin_spec.rb
@@ -28,19 +28,27 @@ describe FeedbinAPI do
     end
   end
 
-  describe '#tag' do
-    it 'should get subscriptions and return a 200' do
-      stub_request(:get, "https://api.feedbin.com/v2/taggings/42.json")
+  describe '#tags' do
+    it 'should get tags and return a 200' do
+      stub_request(:get, "https://api.feedbin.com/v2/tags.json")
         .with(basic_auth: ['email', 'password']).to_return(status: 200)
-      expect(@feedbin.tag(42).code).to eq(200)
+      expect(@feedbin.tags.code).to eq(200)
     end
   end
 
-  describe '#tags' do
-    it 'should get subscriptions and return a 200' do
+  describe '#tagging' do
+    it 'should get a tagging and return a 200' do
+      stub_request(:get, "https://api.feedbin.com/v2/taggings/42.json")
+        .with(basic_auth: ['email', 'password']).to_return(status: 200)
+      expect(@feedbin.tagging(42).code).to eq(200)
+    end
+  end
+
+  describe '#taggings' do
+    it 'should get taggings and return a 200' do
       stub_request(:get, "https://api.feedbin.com/v2/taggings.json")
         .with(basic_auth: ['email', 'password']).to_return(status: 200)
-      expect(@feedbin.tags.code).to eq(200)
+      expect(@feedbin.taggings.code).to eq(200)
     end
   end
 


### PR DESCRIPTION
Adds [tagging](https://github.com/feedbin/feedbin-api/blob/master/content/taggings.md) support via the `tag(id)` and `tags` methods, updates the [api hostname](https://github.com/feedbin/feedbin-api#domain) and updates the specs to recent webmock versions (see https://github.com/bblimke/webmock#important-since-version-200-webmock-does-not-match-credentials-provided-in-authorization-header-and-credentials-provided-in-the-userinfo-of-a-url-ie-stub_requestget-userpasswwwexamplecom-does-not-match-a-request-with-credentials-provided-in-the-authorization-header)